### PR TITLE
Rotation bug

### DIFF
--- a/hammer.js
+++ b/hammer.js
@@ -1783,7 +1783,7 @@ function getScale(start, end) {
  * @return {Number} rotation
  */
 function getRotation(start, end) {
-  return getAngle(end[1], end[0], PROPS_CLIENT_XY) + getAngle(start[1], start[0], PROPS_CLIENT_XY);
+  return getAngle(end[1], end[0], PROPS_CLIENT_XY) - getAngle(start[1], start[0], PROPS_CLIENT_XY);
 }
 
 /**


### PR DESCRIPTION
Fix bug with rotation when add a value for threshold to avoid map being rotated and zoomed at the same time